### PR TITLE
GitHub Actionsでのパス展開エラー修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,8 +25,8 @@ jobs:
 
     - name: Setup credentials file
       run: |
-        mkdir -p ~/.config/gcloud
-        cat > ~/.config/gcloud/application_default_credentials.json << EOF
+        mkdir -p $HOME/.config/gcloud
+        cat > $HOME/.config/gcloud/application_default_credentials.json << EOF
         {
           "type": "service_account",
           "project_id": "${{ secrets.GCP_PROJECT_ID }}",
@@ -44,7 +44,7 @@ jobs:
         
     - name: Authenticate to Google Cloud
       run: |
-        gcloud auth activate-service-account --key-file=~/.config/gcloud/application_default_credentials.json
+        gcloud auth activate-service-account --key-file=$HOME/.config/gcloud/application_default_credentials.json
         gcloud config set project $PROJECT_ID
 
     - name: Set up Cloud SDK


### PR DESCRIPTION
## 概要
GitHub Actionsで発生していたホームディレクトリのパス展開エラーを修正しました。

## 修正したエラー
```
ERROR: (gcloud.auth.activate-service-account) Unable to read file [~/.config/gcloud/application_default_credentials.json]: 
[Errno 2] No such file or directory: '~/.config/gcloud/application_default_credentials.json'
```

## 原因
GitHub Actions環境では、シェルの`~`（チルダ）がホームディレクトリに正しく展開されない

## 解決方法
`.github/workflows/deploy.yml`内の3箇所で`~`を`$HOME`に変更：
- 28行目: `mkdir -p $HOME/.config/gcloud`
- 29行目: `cat > $HOME/.config/gcloud/application_default_credentials.json`
- 47行目: `gcloud auth activate-service-account --key-file=$HOME/.config/gcloud/application_default_credentials.json`

## 変更ファイル
- `.github/workflows/deploy.yml` (3行変更)

## 動作確認
- ✅ 修正後のパスが正しく展開されることを確認
- ✅ 認証ファイルが正常に作成されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)