### PR TITLE
Fix: Workload Identity Federation認証の修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  PROJECT_ID: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
+  PROJECT_ID: growth-force-project
   FUNCTION_NAME: web-pixel-billing-batch
   REGION: asia-northeast1
   
@@ -26,9 +26,9 @@ jobs:
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v2
       with:
-        project_id: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
-        workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-        service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+        project_id: growth-force-project
+        workload_identity_provider: //iam.googleapis.com/projects/32670171847/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+        service_account: github-actions-deploy@growth-force-project.iam.gserviceaccount.com
 
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v2


### PR DESCRIPTION
## 概要
GitHub ActionsでのWorkload Identity Federation認証エラーを解決するため、認証情報をdeploy.ymlに直接埋め込みました。

## 問題
GitHub Secretsから環境変数を読み込む際に、以下のエラーが発生していました：
```
Error: google-github-actions/auth failed with: failed to generate Google Cloud federated token
Invalid value for "audience". This value should be the full resource name of the Identity Provider.
```

## 原因
- GitHub Secretsの値が正しく渡されていない
- WIF_PROVIDERがマスクされて`//iam.googleapis.com/***`と表示される

## 解決策
deploy.ymlに認証情報を直接記載することで、確実に正しい値が使用されるようにしました。

## 変更内容

### `.github/workflows/deploy.yml`
```yaml
# Before (Secretsから読み込み)
workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}

# After (直接記載)
workload_identity_provider: //iam.googleapis.com/projects/32670171847/locations/global/workloadIdentityPools/github-pool/providers/github-provider
service_account: github-actions-deploy@growth-force-project.iam.gserviceaccount.com
```

## セキュリティ考慮事項
- WIF Provider URLとサービスアカウント名は公開情報
- 実際の認証はGitHub ActionsのOIDCトークンで行われる
- リポジトリ制限（Trans-ltd/web-pixel-billing-batch）により他のリポジトリからは使用不可

## テスト項目
- [x] WIF Providerに`Trans-ltd/web-pixel-billing-batch`リポジトリを追加
- [x] サービスアカウントに必要な権限を付与
- [ ] GitHub ActionsでのWIF認証が成功すること
- [ ] Cloud Functionsへのデプロイが完了すること

🤖 Generated with [Claude Code](https://claude.ai/code)