### PR TITLE
Fix: WIF認証のプレフィックス重複を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       uses: google-github-actions/auth@v2
       with:
         project_id: growth-force-project
-        workload_identity_provider: //iam.googleapis.com/projects/32670171847/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+        workload_identity_provider: projects/32670171847/locations/global/workloadIdentityPools/github-pool/providers/github-provider
         service_account: github-actions-deploy@growth-force-project.iam.gserviceaccount.com
 
     - name: Set up Cloud SDK


### PR DESCRIPTION
## 概要
GitHub ActionsのWorkload Identity Federation認証で発生していたプレフィックス重複エラーを修正しました。

## 問題
以下のエラーが発生していました：
```
Error: google-github-actions/auth failed with: failed to generate Google Cloud federated token for 
//iam.googleapis.com///iam.googleapis.com/projects/32670171847/locations/global/workloadIdentityPools/github-pool/providers/github-provider
```

`//iam.googleapis.com/`が二重に付与されていました。

## 原因
`google-github-actions/auth@v2`アクションが自動的に`//iam.googleapis.com/`プレフィックスを追加するため、手動で追加していたプレフィックスと重複していました。

## 修正内容

### `.github/workflows/deploy.yml`
```yaml
# Before (プレフィックス付き)
workload_identity_provider: //iam.googleapis.com/projects/32670171847/locations/global/workloadIdentityPools/github-pool/providers/github-provider

# After (プレフィックスなし)
workload_identity_provider: projects/32670171847/locations/global/workloadIdentityPools/github-pool/providers/github-provider
```

## 影響範囲
- GitHub ActionsのWIF認証処理のみ
- デプロイプロセス自体には影響なし

## テスト
- [ ] GitHub ActionsでWIF認証が成功すること
- [ ] Cloud Functionsへのデプロイが正常に完了すること

## 参考
- [google-github-actions/auth ドキュメント](https://github.com/google-github-actions/auth)
- WIF Provider形式: アクションが自動的に`//iam.googleapis.com/`を付与

🤖 Generated with [Claude Code](https://claude.ai/code)