### PR TITLE
fix: add default values for memory and timeout in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,8 +57,8 @@ jobs:
           --entry-point=processBilling \
           --trigger-http \
           --allow-unauthenticated \
-          --memory=${{ secrets.FUNCTION_MEMORY }} \
-          --timeout=${{ secrets.FUNCTION_TIMEOUT }} \
+          --memory=${{ secrets.FUNCTION_MEMORY || '256M' }} \
+          --timeout=${{ secrets.FUNCTION_TIMEOUT || '540s' }} \
           --max-instances=1 \
           --set-env-vars="GOOGLE_CLOUD_PROJECT=${{ secrets.GOOGLE_CLOUD_PROJECT }},NODE_ENV=${{ secrets.NODE_ENV }}"
 


### PR DESCRIPTION
## Summary
- デプロイワークフローのメモリとタイムアウトにデフォルト値を追加
- GitHub Secretsが未設定でもデプロイが成功するように修正

## 問題
GitHub Actionsでのデプロイ時に以下のエラーが発生:
```
ERROR: (gcloud.functions.deploy) argument --timeout: value must be greater than or equal to 1s
```
`FUNCTION_TIMEOUT` secretが空または無効な値だったため、gcloud functions deployコマンドが失敗していました。

## 修正内容
デフォルトのフォールバック値を追加:
- メモリ: 256M (FUNCTION_MEMORYが未設定の場合)
- タイムアウト: 540s (FUNCTION_TIMEOUTが未設定の場合)

これによりSecretsが設定されていなくてもデプロイが成功します。

## テスト計画
- [ ] GitHub ActionsでデプロイWorkflowが正常に実行されることを確認
- [ ] Cloud Functionsへのデプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)