### PR TITLE
Fix: Cloud Functions Gen2 deployment permission error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,26 @@ jobs:
       with:
         project_id: ${{ env.PROJECT_ID }}
 
+    - name: Verify IAM permissions
+      run: |
+        echo "Checking IAM permissions for service account..."
+        SERVICE_ACCOUNT="github-actions-deploy@growth-force-project.iam.gserviceaccount.com"
+        
+        # Check if the service account has necessary roles
+        REQUIRED_ROLES=(
+          "roles/cloudfunctions.admin"
+          "roles/run.admin"
+        )
+        
+        echo "Current IAM policy for $SERVICE_ACCOUNT:"
+        gcloud projects get-iam-policy $PROJECT_ID \
+          --flatten="bindings[].members" \
+          --filter="bindings.members:serviceAccount:$SERVICE_ACCOUNT" \
+          --format="table(bindings.role)" || true
+        
+        echo ""
+        echo "Note: If deployment fails with permission errors, run scripts/setup-iam-permissions.sh locally"
+
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,7 +96,7 @@ jobs:
             --time-zone="Asia/Tokyo" \
             --uri="$FUNCTION_URL" \
             --http-method=POST \
-            --headers="Content-Type=application/json" \
+            --update-headers="Content-Type=application/json" \
             --message-body="{}"
         else
           echo "Creating new scheduler job..."

--- a/README-IAM-SETUP.md
+++ b/README-IAM-SETUP.md
@@ -1,0 +1,50 @@
+# IAM権限設定ガイド
+
+## エラーの解決方法
+
+Cloud Functions (Gen2) のデプロイで以下のエラーが発生した場合：
+
+```
+ERROR: (gcloud.functions.deploy) ResponseError: status=[403], code=[Ok], message=[Permission 'run.services.setIamPolicy' denied on resource...
+```
+
+### 原因
+GitHub ActionsのサービスアカウントにCloud Run関連の権限が不足しています。
+Cloud Functions Gen2はCloud Run上で動作するため、追加の権限が必要です。
+
+### 解決手順
+
+1. **ローカルでGCPにログイン**
+   ```bash
+   gcloud auth login
+   gcloud config set project growth-force-project
+   ```
+
+2. **権限設定スクリプトを実行**
+   ```bash
+   bash ./scripts/setup-iam-permissions.sh
+   ```
+
+   このスクリプトは以下のロールを付与します：
+   - `roles/cloudfunctions.admin` - Cloud Functions管理権限
+   - `roles/run.admin` - Cloud Run管理権限（Gen2に必要）
+   - `roles/iam.serviceAccountUser` - サービスアカウント使用権限
+   - `roles/storage.objectAdmin` - ストレージ権限
+   - `roles/artifactregistry.writer` - Artifact Registry書き込み権限
+
+3. **GitHub Actionsワークフローを再実行**
+   - GitHubのActionsタブから失敗したワークフローを再実行
+   - または新しいコミットをpush
+
+### 権限の確認方法
+
+```bash
+gcloud projects get-iam-policy growth-force-project \
+  --flatten="bindings[].members" \
+  --filter="bindings.members:serviceAccount:github-actions-deploy@growth-force-project.iam.gserviceaccount.com" \
+  --format="table(bindings.role)"
+```
+
+### 注意事項
+- これらの権限変更にはプロジェクトのオーナー権限またはIAM管理者権限が必要です
+- 権限の付与後、反映まで数分かかる場合があります

--- a/scripts/setup-iam-permissions.sh
+++ b/scripts/setup-iam-permissions.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# IAM権限設定スクリプト
+# Cloud Functions (Gen2) デプロイに必要な権限を設定します
+
+set -e
+
+PROJECT_ID="growth-force-project"
+SERVICE_ACCOUNT="github-actions-deploy@growth-force-project.iam.gserviceaccount.com"
+
+echo "Setting up IAM permissions for Cloud Functions deployment..."
+echo "Project: $PROJECT_ID"
+echo "Service Account: $SERVICE_ACCOUNT"
+echo ""
+
+# 必要なロールを配列で定義
+ROLES=(
+    "roles/cloudfunctions.admin"
+    "roles/run.admin"
+    "roles/iam.serviceAccountUser"
+    "roles/storage.objectAdmin"
+    "roles/artifactregistry.writer"
+)
+
+# 各ロールを付与
+for ROLE in "${ROLES[@]}"
+do
+    echo "Granting $ROLE..."
+    gcloud projects add-iam-policy-binding $PROJECT_ID \
+        --member="serviceAccount:$SERVICE_ACCOUNT" \
+        --role="$ROLE" \
+        --quiet
+    
+    if [ $? -eq 0 ]; then
+        echo "✅ Successfully granted $ROLE"
+    else
+        echo "❌ Failed to grant $ROLE"
+        exit 1
+    fi
+    echo ""
+done
+
+echo "✅ All IAM permissions have been successfully configured!"
+echo ""
+echo "The following roles have been granted to $SERVICE_ACCOUNT:"
+for ROLE in "${ROLES[@]}"
+do
+    echo "  - $ROLE"
+done


### PR DESCRIPTION
## Summary
- Cloud Functions Gen2のデプロイ時に発生するIAM権限エラーを修正
- 必要な権限を設定するためのスクリプトとドキュメントを追加
- デプロイワークフローにIAM権限チェックステップを追加

## 問題
Cloud Functions Gen2のデプロイで以下のエラーが発生:
```
Permission 'run.services.setIamPolicy' denied on resource 'projects/growth-force-project/locations/asia-northeast1/services/web-pixel-billing-batch'
```

## 解決策
1. IAM権限設定スクリプト (`scripts/setup-iam-permissions.sh`) を作成
   - `roles/cloudfunctions.admin`
   - `roles/run.admin` (Gen2に必要)
   - `roles/iam.serviceAccountUser`
   - `roles/storage.objectAdmin`
   - `roles/artifactregistry.writer`

2. デプロイワークフローに権限チェックステップを追加
3. セットアップ手順のドキュメントを追加

## テストプラン
- [ ] ローカルで `scripts/setup-iam-permissions.sh` を実行
- [ ] GitHub Actionsのデプロイワークフローが正常に動作することを確認
- [ ] Cloud Functions Gen2が正常にデプロイされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)