### PR TITLE
refactor: standardize field names from shop_domain to shop

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ gcloud logs read "resource.type=cloud_scheduler_job" --limit=10
 ```sql
 -- 課金レコードを確認
 SELECT 
-  shop_domain,
+  shop,
   billing_date,
   page_views,
   billing_amount,

--- a/src/services/bigquery.ts
+++ b/src/services/bigquery.ts
@@ -19,7 +19,7 @@ export class BigQueryService {
   async getActiveShopifySessions(): Promise<ShopifySession[]> {
     const query = `
       SELECT 
-        shop AS shop_domain,
+        shop,
         accessToken,
         createdAt AS created_at,
         updatedAt AS updated_at
@@ -34,14 +34,14 @@ export class BigQueryService {
     // session_idを生成（shopをそのまま使用）
     return rows.map((row: Record<string, unknown>) => ({
       ...row,
-      session_id: (row as unknown as ShopifySession).shop_domain
+      session_id: (row as unknown as ShopifySession).shop
     })) as ShopifySession[];
   }
 
   async getPageViewsForDate(targetDate: string): Promise<PageViewEvent[]> {
     const query = `
       SELECT 
-        shop AS shop_domain,
+        shop,
         COUNT(*) as event_count
       FROM \`${this.projectId}.ad_analytics.events\`
       WHERE name = 'page_viewed'
@@ -77,7 +77,7 @@ export class BigQueryService {
       console.log('Creating usage_records table...');
       await table.create({
         schema: [
-          { name: 'shop_domain', type: 'STRING', mode: 'REQUIRED' },
+          { name: 'shop', type: 'STRING', mode: 'REQUIRED' },
           { name: 'billing_date', type: 'DATE', mode: 'REQUIRED' },
           { name: 'page_views', type: 'INTEGER', mode: 'REQUIRED' },
           { name: 'billing_amount', type: 'FLOAT', mode: 'REQUIRED' },
@@ -99,7 +99,7 @@ export class BigQueryService {
   async getBillingRecordsForDate(targetDate: string): Promise<BillingRecord[]> {
     const query = `
       SELECT 
-        shop_domain,
+        shop,
         billing_date,
         page_views,
         billing_amount,

--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -88,17 +88,17 @@ export class BillingService {
     billingDate: string
   ): BillingRecord[] {
     const pageViewsMap = new Map(
-      pageViews.map(pv => [pv.shop_domain, pv.event_count])
+      pageViews.map(pv => [pv.shop, pv.event_count])
     );
 
     const billingRecords: BillingRecord[] = [];
 
     for (const session of sessions) {
-      const viewCount = pageViewsMap.get(session.shop_domain) || 0;
+      const viewCount = pageViewsMap.get(session.shop) || 0;
       const billingAmount = this.calculateBillingAmount(viewCount);
 
       billingRecords.push({
-        shop_domain: session.shop_domain,
+        shop: session.shop,
         billing_date: billingDate,
         page_views: viewCount,
         billing_amount: billingAmount,
@@ -135,7 +135,7 @@ export class BillingService {
     
     console.log('\nSample billing records:');
     billingRecords.slice(0, 5).forEach(record => {
-      console.log(`- ${record.shop_domain}: ${record.page_views.toLocaleString()} views = $${record.billing_amount}`);
+      console.log(`- ${record.shop}: ${record.page_views.toLocaleString()} views = $${record.billing_amount}`);
     });
   }
 }

--- a/src/types/billing.ts
+++ b/src/types/billing.ts
@@ -1,18 +1,18 @@
 export interface ShopifySession {
   session_id: string;
-  shop_domain: string;
+  shop: string;
   accessToken: string;
   created_at: string;
   updated_at: string;
 }
 
 export interface PageViewEvent {
-  shop_domain: string;
+  shop: string;
   event_count: number;
 }
 
 export interface BillingRecord {
-  shop_domain: string;
+  shop: string;
   billing_date: string;
   page_views: number;
   billing_amount: number;


### PR DESCRIPTION
## Summary
- Standardized field naming across the codebase by replacing `shop_domain` with `shop`
- Ensures consistency with existing BigQuery source tables that already use the `shop` field

## Changes
- Updated BigQuery schema definitions in table creation
- Modified TypeScript interfaces: `ShopifySession`, `PageViewEvent`, `BillingRecord`
- Updated all SQL queries to use consistent field naming
- Refactored code variables to match the new naming convention

## Test plan
- [x] All TypeScript compilation checks pass
- [x] ESLint checks pass  
- [x] Pre-commit hooks pass
- [ ] Verify BigQuery queries execute correctly with new field names
- [ ] Test billing batch process with updated field names

🤖 Generated with [Claude Code](https://claude.ai/code)